### PR TITLE
일반 후각 훈련 초기 프로토타입 개발 (완)

### DIFF
--- a/lib/common/widgets/button_basic.dart
+++ b/lib/common/widgets/button_basic.dart
@@ -27,6 +27,7 @@ class ButtonBasic extends StatelessWidget {
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(12),
             ),
+            padding: EdgeInsets.all(10),
           ),
           icon: icon,
           label: Text(
@@ -47,6 +48,7 @@ class ButtonBasic extends StatelessWidget {
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(12),
             ),
+            padding: EdgeInsets.all(10),
           ),
           label: Text(
             content,

--- a/lib/features/normal_olfactory_training/data/models/round_log.dart
+++ b/lib/features/normal_olfactory_training/data/models/round_log.dart
@@ -1,0 +1,22 @@
+class RoundLog {
+  final String correctOption;
+  final String selectedOption;
+  final bool isCorrect;
+  final int timeTaken;
+
+  RoundLog({
+    required this.correctOption,
+    required this.selectedOption,
+    required this.isCorrect,
+    required this.timeTaken,
+  });
+
+   Map<String, dynamic> toJson() {
+    return {
+      'correctOption': correctOption,
+      'selectedOption': selectedOption,
+      'isCorrect': isCorrect,
+      'timeTaken': timeTaken,
+    };
+  }
+}

--- a/lib/features/normal_olfactory_training/data/models/scent_options.dart
+++ b/lib/features/normal_olfactory_training/data/models/scent_options.dart
@@ -1,0 +1,25 @@
+class ScentOptions {
+  final String correctOption;
+  final String scentOption1;
+  final String scentOption2;
+  final String scentOption3;
+  final String scentOption4;
+
+  ScentOptions({
+    required this.correctOption,
+    required this.scentOption1,
+    required this.scentOption2,
+    required this.scentOption3,
+    required this.scentOption4,
+  });
+
+  factory ScentOptions.fromJson(Map<String, dynamic> json) {
+    return ScentOptions(
+      correctOption: json['correctOption'],
+      scentOption1: json['scentOption1'],
+      scentOption2: json['scentOption2'],
+      scentOption3: json['scentOption3'],
+      scentOption4: json['scentOption4'],
+    );
+  }
+}

--- a/lib/features/normal_olfactory_training/data/normal_olfactory_training_api.dart
+++ b/lib/features/normal_olfactory_training/data/normal_olfactory_training_api.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+
+import 'package:deepscent_cnu/features/normal_olfactory_training/data/models/scent_options.dart';
+import 'package:deepscent_cnu/secrets.dart';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+class NormalOlfactoryTrainingApi {
+  static Future<ScentOptions?> getScentOptions(int round) async {
+    final apiUrl =
+        '$apiBaseUrl/api/device/$deviceId/fragrance/scent-option?round=$round';
+    final requestHeaders = {'Content-type': 'application/json'};
+
+    try {
+      final response = await http.get(
+        Uri.parse(apiUrl),
+        headers: requestHeaders,
+      );
+
+      if (response.statusCode == 200) {
+        debugPrint('(Debug) 응답 상태 코드: ${response.statusCode}');
+
+        final jsonData = jsonDecode(utf8.decode(response.bodyBytes));
+        return ScentOptions.fromJson(jsonData);
+      } else {
+        debugPrint('(Debug) 문제 선택지 API 호출 중 오류 발생');
+        return null;
+      }
+    } catch (e) {
+      debugPrint('(Debug) 문제 선택지 API 호출 중 오류 발생: $e');
+    }
+    return null;
+  }
+
+  static Future<void> submitTrainingLog(
+    int totalTimeTaken,
+    List<Map<String, dynamic>> roundLogs,
+  ) async {
+    final apiUrl = '$apiBaseUrl/api/normal-olfactory-training/log';
+    final requestHeaders = {
+      'Content-type': 'application/json',
+      'Authorization': 'Bearer $memberToken',
+    };
+
+    try {
+      final response = await http.post(
+        Uri.parse(apiUrl),
+        headers: requestHeaders,
+        body: jsonEncode({
+          'totalTimeTaken': totalTimeTaken,
+          'roundLogs': roundLogs,
+        }),
+      );
+
+      if (response.statusCode == 204) {
+        debugPrint(
+          '(Debug) 일반 후각 훈련 로그 등록 API 응답 상태 코드: ${response.statusCode}',
+        );
+      } else {
+        debugPrint('(Debug) 일반 후각 훈련 로그 등록 실패: ${response.statusCode}');
+        debugPrint(
+          '(Debug) 응답 본문: ${jsonDecode(utf8.decode(response.bodyBytes))}',
+        );
+      }
+    } catch (e) {
+      debugPrint('(Debug) 일반 후각 훈련 로그 등록 API 호출 중 오류 발생: $e');
+    }
+  }
+}

--- a/lib/features/normal_olfactory_training/presentation/controllers/normal_olfactory_training_controller.dart
+++ b/lib/features/normal_olfactory_training/presentation/controllers/normal_olfactory_training_controller.dart
@@ -1,20 +1,22 @@
+import 'package:deepscent_cnu/features/normal_olfactory_training/data/models/round_log.dart';
 import 'package:get/get.dart';
 
 class NormalOlfactoryTrainingController extends GetxController {
   var currentRound = 1.obs;
+  var correctOption = '';
+  var isCorrect = false;
+  var totalScore = 0;
+  var totalTimeTaken = 0;
   final totalRounds = 4;
 
   var logs = <RoundLog>[].obs;
-}
 
-class RoundLog {
-  final String correctScent;
-  final String selectedScent;
-  final int timeTaken;
-
-  RoundLog({
-    required this.correctScent,
-    required this.selectedScent,
-    required this.timeTaken,
-  });
+  void reset() {
+    currentRound.value = 1;
+    correctOption = '';
+    isCorrect = false;
+    totalScore = 0;
+    totalTimeTaken = 0;
+    logs.clear();
+  }
 }

--- a/lib/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_answer.dart
+++ b/lib/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_answer.dart
@@ -1,4 +1,8 @@
+import 'dart:math';
+
 import 'package:deepscent_cnu/common/widgets/button_basic.dart';
+import 'package:deepscent_cnu/features/normal_olfactory_training/data/models/round_log.dart';
+import 'package:deepscent_cnu/features/normal_olfactory_training/data/normal_olfactory_training_api.dart';
 import 'package:deepscent_cnu/features/normal_olfactory_training/presentation/controllers/normal_olfactory_training_controller.dart';
 import 'package:deepscent_cnu/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_result.dart';
 import 'package:deepscent_cnu/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_screen.dart';
@@ -99,8 +103,27 @@ class NormalOlfactoryTrainingAnswerScreen extends StatelessWidget {
     );
   }
 
-  void nextRound() {
+  void nextRound() async {
     if (normalOlfactoryTrainingController.currentRound.value == 4) {
+      var totalScore = 0;
+      var totalTimeTaken = 0;
+
+      for (RoundLog log in normalOlfactoryTrainingController.logs) {
+        if (log.isCorrect) {
+          totalScore++;
+        }
+
+        totalTimeTaken += log.timeTaken;
+      }
+
+      normalOlfactoryTrainingController.totalScore = totalScore;
+      normalOlfactoryTrainingController.totalTimeTaken = totalTimeTaken;
+
+      await NormalOlfactoryTrainingApi.submitTrainingLog(
+        totalTimeTaken,
+        normalOlfactoryTrainingController.logs.map((e) => e.toJson()).toList()
+      );
+
       Get.off(() => NormalOlfactoryTrainingResultScreen());
     } else {
       normalOlfactoryTrainingController.currentRound.value++;
@@ -173,7 +196,7 @@ class NormalOlfactoryTrainingAnswerScreen extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 5),
                     child: Text(
-                      "맞았어요! 방금 맡은 향은\n참기름 향이었습니다.",
+                      '${normalOlfactoryTrainingController.isCorrect ? "맞았어요!" : "앗, 아쉬워요!"} 방금 맡은 향은\n${normalOlfactoryTrainingController.correctOption} 향이었습니다.',
                       style: TextStyle(
                         fontSize: 28,
                         fontWeight: FontWeight.bold,

--- a/lib/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_question.dart
+++ b/lib/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_question.dart
@@ -1,14 +1,46 @@
 import 'package:deepscent_cnu/common/widgets/button_basic.dart';
+import 'package:deepscent_cnu/features/normal_olfactory_training/data/models/round_log.dart';
+import 'package:deepscent_cnu/features/normal_olfactory_training/data/models/scent_options.dart';
+import 'package:deepscent_cnu/features/normal_olfactory_training/data/normal_olfactory_training_api.dart';
 import 'package:deepscent_cnu/features/normal_olfactory_training/presentation/controllers/normal_olfactory_training_controller.dart';
 import 'package:deepscent_cnu/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_answer.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-class NormalOlfactoryTrainingQuestionScreen extends StatelessWidget {
+class NormalOlfactoryTrainingQuestionScreen extends StatefulWidget {
+  const NormalOlfactoryTrainingQuestionScreen({super.key});
+
+  @override
+  State<NormalOlfactoryTrainingQuestionScreen> createState() =>
+      _NormalOlfactoryTrainingQuestionScreenState();
+}
+
+class _NormalOlfactoryTrainingQuestionScreenState
+    extends State<NormalOlfactoryTrainingQuestionScreen> {
   final normalOlfactoryTrainingController =
       Get.find<NormalOlfactoryTrainingController>();
+  bool isLoading = true;
+  ScentOptions? scentOptions;
+  late DateTime startTime;
 
-  NormalOlfactoryTrainingQuestionScreen({super.key});
+  @override
+  void initState() {
+    super.initState();
+    getScentOptions(normalOlfactoryTrainingController.currentRound.value);
+    startTime = DateTime.now();
+  }
+
+  Future<void> getScentOptions(int round) async {
+    scentOptions = await NormalOlfactoryTrainingApi.getScentOptions(round);
+    if (scentOptions != null) {
+      setState(() {
+        isLoading = false;
+      });
+
+      normalOlfactoryTrainingController.correctOption =
+          scentOptions!.correctOption;
+    }
+  }
 
   void showTrainingStopModal(BuildContext context) {
     showDialog(
@@ -98,7 +130,22 @@ class NormalOlfactoryTrainingQuestionScreen extends StatelessWidget {
     );
   }
 
-  void goAnswerScreen() {
+  void goAnswerScreen(String selectedOption) {
+    final endTime = DateTime.now();
+    final timeTaken = endTime.difference(startTime).inSeconds;
+    final correctOption = scentOptions!.correctOption;
+    final isCorrect = selectedOption == correctOption;
+
+    normalOlfactoryTrainingController.isCorrect = isCorrect;
+    normalOlfactoryTrainingController.logs.add(
+      RoundLog(
+        correctOption: correctOption,
+        selectedOption: selectedOption,
+        isCorrect: isCorrect,
+        timeTaken: timeTaken,
+      ),
+    );
+
     Get.off(() => NormalOlfactoryTrainingAnswerScreen());
   }
 
@@ -130,101 +177,134 @@ class NormalOlfactoryTrainingQuestionScreen extends StatelessWidget {
         ],
       ),
       body: SafeArea(
-        child: Stack(
-          children: [
-            Positioned(
-              top: 80,
-              child: Image.asset(
-                'assets/images/blurred_background.png',
-                fit: BoxFit.cover,
-                opacity: AlwaysStoppedAnimation(0.5),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  const SizedBox(height: 24),
-                  Row(
-                    children: [
-                      IconButton(
-                        onPressed: () {
-                          showTrainingStopModal(context);
-                        },
-                        icon: const Icon(Icons.arrow_back_ios_new, size: 20),
-                      ),
-                      const Text(
-                        '일반 후각 훈련',
-                        style: TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 16),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 5),
-                    child: Text(
-                      "방금 맡은 향은 어떤 향인지\n다음 보기 중에서 골라보세요!",
-                      style: TextStyle(
-                        fontSize: 28,
-                        fontWeight: FontWeight.bold,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                  const SizedBox(height: 40),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 24),
-                    child: GridView.count(
-                      shrinkWrap: true,
-                      crossAxisCount: 2,
-                      crossAxisSpacing: 40,
-                      mainAxisSpacing: 40,
-                      childAspectRatio: 1,
+        child:
+            isLoading
+                ? Container(
+                  color: Colors.black.withOpacity(0.5), // 화면 어두워짐
+                  child: Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
                       children: [
-                        ButtonBasic(
-                          content: "백미밥",
-                          fontSize: 24,
-                          function: goAnswerScreen,
-                        ),
-                        ButtonBasic(
-                          content: "참기름",
-                          fontSize: 24,
-                          function: goAnswerScreen,
-                        ),
-                        ButtonBasic(
-                          content: "장미",
-                          fontSize: 24,
-                          function: goAnswerScreen,
-                        ),
-                        ButtonBasic(
-                          content: "된장",
-                          fontSize: 24,
-                          function: goAnswerScreen,
+                        CircularProgressIndicator(color: Colors.white),
+                        SizedBox(height: 16),
+                        Text(
+                          '불러오는 중...',
+                          style: TextStyle(color: Colors.white, fontSize: 16),
                         ),
                       ],
                     ),
                   ),
-                  const SizedBox(height: 32),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 24,
-                      vertical: 16,
+                )
+                : Stack(
+                  children: [
+                    Positioned(
+                      top: 80,
+                      child: Image.asset(
+                        'assets/images/blurred_background.png',
+                        fit: BoxFit.cover,
+                        opacity: AlwaysStoppedAnimation(0.5),
+                      ),
                     ),
-                    child: ButtonBasic(
-                      content: "잘 모르겠어요",
-                      function: goAnswerScreen,
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 20),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          const SizedBox(height: 24),
+                          Row(
+                            children: [
+                              IconButton(
+                                onPressed: () {
+                                  showTrainingStopModal(context);
+                                },
+                                icon: const Icon(
+                                  Icons.arrow_back_ios_new,
+                                  size: 20,
+                                ),
+                              ),
+                              const Text(
+                                '일반 후각 훈련',
+                                style: TextStyle(
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 16),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 5),
+                            child: Text(
+                              "방금 맡은 향은 어떤 향인지\n다음 보기 중에서 골라보세요!",
+                              style: TextStyle(
+                                fontSize: 28,
+                                fontWeight: FontWeight.bold,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                          const SizedBox(height: 40),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 24),
+                            child: GridView.count(
+                              shrinkWrap: true,
+                              crossAxisCount: 2,
+                              crossAxisSpacing: 40,
+                              mainAxisSpacing: 40,
+                              childAspectRatio: 1,
+                              children: [
+                                ButtonBasic(
+                                  content: scentOptions!.scentOption1,
+                                  fontSize: 24,
+                                  function:
+                                      () => goAnswerScreen(
+                                        scentOptions!.scentOption1,
+                                      ),
+                                ),
+                                ButtonBasic(
+                                  content: scentOptions!.scentOption2,
+                                  fontSize: 24,
+                                  function:
+                                      () => goAnswerScreen(
+                                        scentOptions!.scentOption2,
+                                      ),
+                                ),
+                                ButtonBasic(
+                                  content: scentOptions!.scentOption3,
+                                  fontSize: 24,
+                                  function:
+                                      () => goAnswerScreen(
+                                        scentOptions!.scentOption3,
+                                      ),
+                                ),
+                                ButtonBasic(
+                                  content: scentOptions!.scentOption4,
+                                  fontSize: 24,
+                                  function:
+                                      () => goAnswerScreen(
+                                        scentOptions!.scentOption4,
+                                      ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(height: 32),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 24,
+                              vertical: 16,
+                            ),
+                            child: ButtonBasic(
+                              content: "잘 모르겠어요",
+                              function: () => goAnswerScreen(""),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                        ],
+                      ),
                     ),
-                  ),
-                  const SizedBox(height: 12),
-                ],
-              ),
-            ),
-          ],
-        ),
+                  ],
+                ),
       ),
     );
   }

--- a/lib/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_result.dart
+++ b/lib/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_result.dart
@@ -1,8 +1,18 @@
 import 'package:deepscent_cnu/common/widgets/button_basic.dart';
+import 'package:deepscent_cnu/features/normal_olfactory_training/presentation/controllers/normal_olfactory_training_controller.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 
 class NormalOlfactoryTrainingResultScreen extends StatelessWidget {
-  const NormalOlfactoryTrainingResultScreen({super.key});
+  final normalOlfactoryTrainingController =
+      Get.find<NormalOlfactoryTrainingController>();
+
+  NormalOlfactoryTrainingResultScreen({super.key});
+
+  void returnTrainingList(BuildContext context) {
+    normalOlfactoryTrainingController.reset();
+    Navigator.pop(context);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -50,9 +60,7 @@ class NormalOlfactoryTrainingResultScreen extends StatelessWidget {
                     Row(
                       children: [
                         IconButton(
-                          onPressed: () {
-                            Navigator.pop(context);
-                          },
+                          onPressed: () => returnTrainingList(context),
                           icon: const Icon(Icons.arrow_back_ios_new, size: 20),
                         ),
                         const Text(
@@ -82,8 +90,8 @@ class NormalOlfactoryTrainingResultScreen extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(height: 8),
-                    const Text(
-                      '4개의 향기 중, 3개의 향기를 맞추었어요!',
+                    Text(
+                      '4개의 향기 중, ${normalOlfactoryTrainingController.totalScore}개의 향기를 맞추었어요!',
                       style: TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.bold,
@@ -102,24 +110,7 @@ class NormalOlfactoryTrainingResultScreen extends StatelessWidget {
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 6,
-                            vertical: 3,
-                          ),
-                          decoration: BoxDecoration(
-                            color: Color(0xFF335928),
-                            borderRadius: BorderRadius.circular(4),
-                          ),
-                          child: const Text(
-                            '정답',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 20,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ),
+                        resultLabel(context, isCorrect: normalOlfactoryTrainingController.logs[0].isCorrect),
                         const SizedBox(width: 12),
                         Container(
                           width: 32,
@@ -139,39 +130,22 @@ class NormalOlfactoryTrainingResultScreen extends StatelessWidget {
                           ),
                         ),
                         const SizedBox(width: 12),
-                        const Text(
-                          '정답: 참기름',
+                        Text(
+                          '정답: ${normalOlfactoryTrainingController.logs[0].correctOption}',
                           style: TextStyle(
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
                           ),
                         ),
                         const SizedBox(width: 12),
-                        const Text('선택: 참기름', style: TextStyle(fontSize: 18)),
+                        Text('선택: ${normalOlfactoryTrainingController.logs[0].selectedOption}', style: TextStyle(fontSize: 18)),
                       ],
                     ),
                     const SizedBox(height: 18),
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 6,
-                            vertical: 3,
-                          ),
-                          decoration: BoxDecoration(
-                            color: Color(0xFF335928),
-                            borderRadius: BorderRadius.circular(4),
-                          ),
-                          child: const Text(
-                            '정답',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 20,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ),
+                        resultLabel(context, isCorrect: normalOlfactoryTrainingController.logs[1].isCorrect),
                         const SizedBox(width: 12),
                         Container(
                           width: 32,
@@ -191,39 +165,22 @@ class NormalOlfactoryTrainingResultScreen extends StatelessWidget {
                           ),
                         ),
                         const SizedBox(width: 12),
-                        const Text(
-                          '정답: 나프탈렌',
+                        Text(
+                          '정답: ${normalOlfactoryTrainingController.logs[1].correctOption}',
                           style: TextStyle(
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
                           ),
                         ),
                         const SizedBox(width: 12),
-                        const Text('선택: 나프탈렌', style: TextStyle(fontSize: 18)),
+                        Text('선택: ${normalOlfactoryTrainingController.logs[1].selectedOption}', style: TextStyle(fontSize: 18)),
                       ],
                     ),
                     const SizedBox(height: 18),
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 6,
-                            vertical: 3,
-                          ),
-                          decoration: BoxDecoration(
-                            color: Color(0xFF335928),
-                            borderRadius: BorderRadius.circular(4),
-                          ),
-                          child: const Text(
-                            '정답',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 20,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ),
+                        resultLabel(context, isCorrect: normalOlfactoryTrainingController.logs[2].isCorrect),
                         const SizedBox(width: 12),
                         Container(
                           width: 32,
@@ -243,39 +200,22 @@ class NormalOlfactoryTrainingResultScreen extends StatelessWidget {
                           ),
                         ),
                         const SizedBox(width: 12),
-                        const Text(
-                          '정답: 청국장',
+                        Text(
+                          '정답: ${normalOlfactoryTrainingController.logs[2].correctOption}',
                           style: TextStyle(
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
                           ),
                         ),
                         const SizedBox(width: 12),
-                        const Text('선택: 청국장', style: TextStyle(fontSize: 18)),
+                        Text('선택: ${normalOlfactoryTrainingController.logs[2].selectedOption}', style: TextStyle(fontSize: 18)),
                       ],
                     ),
                     const SizedBox(height: 18),
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 6,
-                            vertical: 3,
-                          ),
-                          decoration: BoxDecoration(
-                            color: Color(0xFFFF5353),
-                            borderRadius: BorderRadius.circular(4),
-                          ),
-                          child: const Text(
-                            '오답',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 20,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ),
+                        resultLabel(context, isCorrect: normalOlfactoryTrainingController.logs[3].isCorrect),
                         const SizedBox(width: 12),
                         Container(
                           width: 32,
@@ -295,15 +235,15 @@ class NormalOlfactoryTrainingResultScreen extends StatelessWidget {
                           ),
                         ),
                         const SizedBox(width: 12),
-                        const Text(
-                          '정답: 레몬',
+                        Text(
+                          '정답: ${normalOlfactoryTrainingController.logs[3].correctOption}',
                           style: TextStyle(
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
                           ),
                         ),
                         const SizedBox(width: 12),
-                        const Text('선택: 오렌지', style: TextStyle(fontSize: 18)),
+                        Text('선택: ${normalOlfactoryTrainingController.logs[3].selectedOption}', style: TextStyle(fontSize: 18)),
                       ],
                     ),
                     const SizedBox(height: 48),
@@ -316,8 +256,8 @@ class NormalOlfactoryTrainingResultScreen extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(height: 4),
-                    const Text(
-                      '2분 17초',
+                    Text(
+                      '${normalOlfactoryTrainingController.totalTimeTaken ~/ 60}분 ${normalOlfactoryTrainingController.totalTimeTaken % 60}초',
                       style: TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.bold,
@@ -344,7 +284,7 @@ class NormalOlfactoryTrainingResultScreen extends StatelessWidget {
                       child: ButtonBasic(
                         content: '훈련 목록 보기',
                         icon: Icon(Icons.list, size: 30),
-                        function: () {},
+                        function: () => returnTrainingList(context),
                       ),
                     ),
                   ],
@@ -355,5 +295,39 @@ class NormalOlfactoryTrainingResultScreen extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Widget resultLabel(BuildContext context, {required bool isCorrect}) {
+    return isCorrect
+        ? Container(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+          decoration: BoxDecoration(
+            color: Color(0xFF335928),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: const Text(
+            '정답',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        )
+        : Container(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+          decoration: BoxDecoration(
+            color: Color(0xFFFF5353),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: const Text(
+            '오답',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        );
   }
 }

--- a/lib/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_screen.dart
+++ b/lib/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_screen.dart
@@ -1,3 +1,4 @@
+import 'package:deepscent_cnu/common/data/device_api.dart';
 import 'package:deepscent_cnu/common/widgets/button_basic.dart';
 import 'package:deepscent_cnu/features/normal_olfactory_training/presentation/controllers/normal_olfactory_training_controller.dart';
 import 'package:deepscent_cnu/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_question.dart';
@@ -16,7 +17,7 @@ class _NormalOlfactoryTrainingScreenState
     extends State<NormalOlfactoryTrainingScreen> {
   final normalOlfactoryTrainingController =
       Get.find<NormalOlfactoryTrainingController>();
-  int remainTime = 10;
+  int remainTime = 2;
   String message = "초 뒤, 발향이 중지됩니다.";
   bool isStopped = false;
 
@@ -28,7 +29,10 @@ class _NormalOlfactoryTrainingScreenState
 
   Future<void> startTrainingCycle() async {
     isStopped = false;
-    // await DeviceApi.controlScentDeviceSlot(normalOlfactoryTrainingController.currentRound.value, 3);
+    await DeviceApi.controlScentDeviceSlot(
+      normalOlfactoryTrainingController.currentRound.value,
+      3,
+    );
     await Future.delayed(const Duration(seconds: 1));
 
     while (remainTime > 1) {
@@ -44,7 +48,10 @@ class _NormalOlfactoryTrainingScreenState
     }
 
     if (!isStopped && context.mounted) {
-      // await DeviceApi.controlScentDeviceSlot(normalOlfactoryTrainingController.currentRound.value, 0);
+      await DeviceApi.controlScentDeviceSlot(
+        normalOlfactoryTrainingController.currentRound.value,
+        0,
+      );
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(
@@ -56,7 +63,10 @@ class _NormalOlfactoryTrainingScreenState
 
   Future<void> stopTrainingCycle() async {
     isStopped = true;
-    // await DeviceApi.controlScentDeviceSlot(normalOlfactoryTrainingController.currentRound.value, 0);
+    await DeviceApi.controlScentDeviceSlot(
+      normalOlfactoryTrainingController.currentRound.value,
+      0,
+    );
 
     if (context.mounted) {
       Navigator.pop(context);


### PR DESCRIPTION
- 향기 선택지 API 구현
- 각 라운드 수에 따른 문제 향, 선택 향, 선택에 걸린 시간 등 상태 관리
- 훈련 데이터 결과 화면에 뿌리고 컨트롤러 로그 정리하기
- 훈련 데이터 백에 보내서 로그 생성하는 로직

## 참고사항

- 현재 테스트를 위해서는 먼저 로컬에 백엔드 서버를 띄워놓고, 회원가입 API를 Postman 등으로 호출해서 아무 계정을 생성 후, 해당 계정의 액세스 토큰을 플러터 프로젝트의 secret.dart에 반영해주면 됨
- 개발 편의를 위해 액세스 토큰 검증 범위를 회원 탈퇴, 일반 후각 훈련 로그 등록에만 한정해두었음
- 위 테스트 프로세스가 좀 번거로운데, 스프링 시큐리티로 비밀번호를 해시화해서 DB에 저장하다보니 data.sql 등의 활용이 제한적이라서 일단 이렇게 하게 됨. 다른 대안은 추후 더 고민해볼 예정