### PR TITLE
인증 관련 변경 및 일반 후각 훈련 휴식 화면 개발

### DIFF
--- a/lib/common/data/device_api.dart
+++ b/lib/common/data/device_api.dart
@@ -1,7 +1,9 @@
 import 'dart:convert';
 
+import 'package:deepscent_cnu/common/presentation/controller/auth_controller.dart';
 import 'package:deepscent_cnu/secrets.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
 
 class DeviceApi {
@@ -9,10 +11,14 @@ class DeviceApi {
     int fanNumber,
     int fanSpeed,
   ) async {
+    final authController = Get.find<AuthController>();
     final apiUrl =
         apiBaseUrl + '/api/device/' + deviceId + "/fragrance/fan-state";
 
-    final requestHeaders = {'Content-type': 'application/json'};
+    final requestHeaders = {
+      'Content-type': 'application/json',
+      'Authorization': 'Bearer ${authController.accessToken.value}',
+    };
 
     final requestBody = jsonEncode({
       'fan_number': fanNumber,

--- a/lib/common/presentation/controller/auth_controller.dart
+++ b/lib/common/presentation/controller/auth_controller.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:deepscent_cnu/secrets.dart';
+import 'package:flutter/widgets.dart';
+import 'package:get/get.dart';
+import 'package:http/http.dart' as http;
+
+class AuthController extends GetxController {
+  var accessToken = ''.obs;
+
+  Future<void> adminLogin() async {
+    final apiUrl = '$apiBaseUrl/api/auth/login';
+    final requestHeaders = {'Content-type': 'application/json'};
+
+    try {
+      final response = await http.post(
+        Uri.parse(apiUrl),
+        headers: requestHeaders,
+        body: jsonEncode({
+          'username': adminUsername,
+          'password': adminPassword,
+        }),
+      );
+
+      if (response.statusCode == 200) {
+        debugPrint('(Debug) 관리자 로그인 API 응답 상태 코드: ${response.statusCode}');
+
+        final Map<String, dynamic> body = jsonDecode(
+          utf8.decode(response.bodyBytes),
+        );
+
+        accessToken.value = body['data'];
+      } else {
+        debugPrint('(Debug) 관리자 로그인 실패: ${response.statusCode}');
+        debugPrint(
+          '(Debug) 응답 본문: ${jsonDecode(utf8.decode(response.bodyBytes))}',
+        );
+      }
+    } catch (e) {
+      debugPrint('(Debug) 관리자 로그인 중 오류 발생 : $e');
+    }
+  }
+}

--- a/lib/dev/main_preview.dart
+++ b/lib/dev/main_preview.dart
@@ -1,11 +1,17 @@
+import 'package:deepscent_cnu/common/presentation/controller/auth_controller.dart';
 import 'package:deepscent_cnu/features/normal_olfactory_training/presentation/controllers/normal_olfactory_training_controller.dart';
 import 'package:deepscent_cnu/features/training_list/presentation/screens/olfactory_training_list.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final authController = Get.put(AuthController());
+  await authController.adminLogin();
+
   Get.put(NormalOlfactoryTrainingController());
   runApp(const MyApp());
+  debugPrint(authController.accessToken.value);
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/features/login/data/auth_api.dart
+++ b/lib/features/login/data/auth_api.dart
@@ -1,4 +1,5 @@
 // lib/src/features/auth/data/auth_api.dart
+import 'package:deepscent_cnu/secrets.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 
@@ -7,7 +8,7 @@ class AuthApi {
     required String username,
     required String password,
   }) async {
-    final url = Uri.parse('http://localhost:8080/api/auth/login');
+    final url = Uri.parse('$apiBaseUrl/api/auth/login');
     return await http.post(
       url,
       headers: {'Content-Type': 'application/json'},
@@ -25,7 +26,7 @@ class AuthApi {
     required String username,
     required String password,
   }) async {
-    final url = Uri.parse('http://localhost:8080/api/auth/signup');
+    final url = Uri.parse('$apiBaseUrl/api/auth/signup');
     return await http.post(
       url,
       headers: {'Content-Type': 'application/json'},

--- a/lib/features/login/presentation/screens/login.dart
+++ b/lib/features/login/presentation/screens/login.dart
@@ -1,8 +1,10 @@
+import 'package:deepscent_cnu/common/presentation/controller/auth_controller.dart';
+import 'package:deepscent_cnu/features/training_list/presentation/screens/olfactory_training_list.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'signup.dart';
 import '../../data/auth_api.dart'; 
 import 'dart:convert';
-import '../../../normal_olfactory_training/presentation/screens/normal_olfactory_training_screen.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -12,6 +14,7 @@ class LoginPage extends StatefulWidget {
 }
 
 class _LoginPageState extends State<LoginPage> {
+  final authController = Get.find<AuthController>();
   final TextEditingController idController = TextEditingController();
   final TextEditingController pwController = TextEditingController();
 
@@ -23,12 +26,13 @@ Future<void> handleLogin() async {
 
   if (response.statusCode == 200) {
     final data = jsonDecode(response.body);
+    authController.accessToken.value = data['data'];
     print('로그인 성공: $data');
 
     Navigator.pushReplacement(
       context,
       MaterialPageRoute(
-        builder: (context) => const NormalOlfactoryTrainingScreen(),
+        builder: (context) => const OlfactoryTrainingListScreen(),
       ),
     );
   } else {

--- a/lib/features/login/presentation/screens/signup.dart
+++ b/lib/features/login/presentation/screens/signup.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '../../data/auth_api.dart'; 
+import '../../data/auth_api.dart';
 import 'dart:convert';
 
 class SignUpPage extends StatefulWidget {
@@ -27,35 +27,39 @@ class _SignUpPageState extends State<SignUpPage> {
 
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body);
-      print('회원가입 성공: $data');
+      debugPrint('회원가입 성공: $data');
       showDialog(
         context: context,
-        builder: (_) => AlertDialog(
-          title: const Text("회원가입 완료"),
-          content: const Text("로그인 화면으로 이동합니다."),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text("확인"),
+        builder:
+            (_) => AlertDialog(
+              title: const Text("회원가입 완료"),
+              content: const Text("로그인 화면으로 이동합니다."),
+              actions: [
+                TextButton(
+                  onPressed: () {
+                    Navigator.pop(context);
+                    Navigator.pop(context);
+                  },
+                  child: const Text("확인"),
+                ),
+              ],
             ),
-          ],
-        ),
       );
-      Navigator.pop(context); // 이전 페이지로 (로그인)
     } else {
-      print('회원가입 실패: ${response.body}');
+      debugPrint('회원가입 실패: ${response.body}');
       showDialog(
         context: context,
-        builder: (_) => AlertDialog(
-          title: const Text("회원가입 실패"),
-          content: const Text("정보를 다시 확인해주세요."),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text("확인"),
+        builder:
+            (_) => AlertDialog(
+              title: const Text("회원가입 실패"),
+              content: const Text("정보를 다시 확인해주세요."),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text("확인"),
+                ),
+              ],
             ),
-          ],
-        ),
       );
     }
   }
@@ -97,9 +101,17 @@ class _SignUpPageState extends State<SignUpPage> {
                 const SizedBox(height: 12),
                 _buildTextField('전화번호를 입력해주세요.', controller: phoneController),
                 const SizedBox(height: 12),
-                _buildTextField('ID를 입력해주세요.', controller: idController, isBold: true),
+                _buildTextField(
+                  'ID를 입력해주세요.',
+                  controller: idController,
+                  isBold: true,
+                ),
                 const SizedBox(height: 12),
-                _buildTextField('비밀번호를 입력해주세요.', controller: pwController, isObscure: true),
+                _buildTextField(
+                  '비밀번호를 입력해주세요.',
+                  controller: pwController,
+                  isObscure: true,
+                ),
                 const SizedBox(height: 24),
                 SizedBox(
                   width: double.infinity,
@@ -112,10 +124,7 @@ class _SignUpPageState extends State<SignUpPage> {
                       ),
                     ),
                     onPressed: handleSignUp,
-                    child: const Text(
-                      '회원가입',
-                      style: TextStyle(fontSize: 18),
-                    ),
+                    child: const Text('회원가입', style: TextStyle(fontSize: 18)),
                   ),
                 ),
               ],
@@ -126,7 +135,8 @@ class _SignUpPageState extends State<SignUpPage> {
     );
   }
 
-  Widget _buildTextField(String hintText, {
+  Widget _buildTextField(
+    String hintText, {
     required TextEditingController controller,
     bool isObscure = false,
     bool isBold = false,
@@ -136,10 +146,10 @@ class _SignUpPageState extends State<SignUpPage> {
       obscureText: isObscure,
       decoration: InputDecoration(
         hintText: hintText,
-        hintStyle: TextStyle(fontWeight: isBold ? FontWeight.bold : FontWeight.normal),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
+        hintStyle: TextStyle(
+          fontWeight: isBold ? FontWeight.bold : FontWeight.normal,
         ),
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(10)),
         filled: true,
         fillColor: Colors.white,
       ),

--- a/lib/features/normal_olfactory_training/data/memory_recall_training_api.dart
+++ b/lib/features/normal_olfactory_training/data/memory_recall_training_api.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;

--- a/lib/features/normal_olfactory_training/data/normal_olfactory_training_api.dart
+++ b/lib/features/normal_olfactory_training/data/normal_olfactory_training_api.dart
@@ -1,15 +1,21 @@
 import 'dart:convert';
 
+import 'package:deepscent_cnu/common/presentation/controller/auth_controller.dart';
 import 'package:deepscent_cnu/features/normal_olfactory_training/data/models/scent_options.dart';
 import 'package:deepscent_cnu/secrets.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
 
 class NormalOlfactoryTrainingApi {
   static Future<ScentOptions?> getScentOptions(int round) async {
+    final authController = Get.find<AuthController>();
     final apiUrl =
         '$apiBaseUrl/api/device/$deviceId/fragrance/scent-option?round=$round';
-    final requestHeaders = {'Content-type': 'application/json'};
+    final requestHeaders = {
+      'Content-type': 'application/json',
+      'Authorization': 'Bearer ${authController.accessToken.value}',
+    };
 
     try {
       final response = await http.get(
@@ -36,10 +42,11 @@ class NormalOlfactoryTrainingApi {
     int totalTimeTaken,
     List<Map<String, dynamic>> roundLogs,
   ) async {
+    final authController = Get.find<AuthController>();
     final apiUrl = '$apiBaseUrl/api/normal-olfactory-training/log';
     final requestHeaders = {
       'Content-type': 'application/json',
-      'Authorization': 'Bearer $memberToken',
+      'Authorization': 'Bearer ${authController.accessToken.value}',
     };
 
     try {

--- a/lib/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_answer.dart
+++ b/lib/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_answer.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:deepscent_cnu/common/data/device_api.dart';
 import 'package:deepscent_cnu/common/widgets/button_basic.dart';
 import 'package:deepscent_cnu/features/normal_olfactory_training/data/models/round_log.dart';
 import 'package:deepscent_cnu/features/normal_olfactory_training/data/normal_olfactory_training_api.dart';
@@ -9,11 +10,57 @@ import 'package:deepscent_cnu/features/normal_olfactory_training/presentation/sc
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-class NormalOlfactoryTrainingAnswerScreen extends StatelessWidget {
+class NormalOlfactoryTrainingAnswerScreen extends StatefulWidget {
+  const NormalOlfactoryTrainingAnswerScreen({super.key});
+
+  @override
+  State<NormalOlfactoryTrainingAnswerScreen> createState() =>
+      _NormalOlfactoryTrainingAnswerScreenState();
+}
+
+class _NormalOlfactoryTrainingAnswerScreenState
+    extends State<NormalOlfactoryTrainingAnswerScreen> {
   final normalOlfactoryTrainingController =
       Get.find<NormalOlfactoryTrainingController>();
+  int remainTime = 20;
+  String message = "초 뒤, 다른 향기가 분출됩니다.";
+  bool isLoading = false;
 
-  NormalOlfactoryTrainingAnswerScreen({super.key});
+  @override
+  void initState() {
+    super.initState();
+    if (normalOlfactoryTrainingController.currentRound.value != 4) {
+      startTrainingCycle();
+    }
+  }
+
+  Future<void> startTrainingCycle() async {
+    await DeviceApi.controlScentDeviceSlot(
+      normalOlfactoryTrainingController.currentRound.value,
+      3,
+    );
+    await Future.delayed(const Duration(seconds: 1));
+
+    while (remainTime > 1) {
+      setState(() {
+        remainTime -= 1;
+      });
+
+      await Future.delayed(const Duration(seconds: 1));
+    }
+
+    setState(() {
+      isLoading = true;
+    });
+
+    await Future.delayed(const Duration(seconds: 1));
+
+    setState(() {
+      isLoading = false;
+    });
+
+    nextRound();
+  }
 
   void showTrainingStopModal(BuildContext context) {
     showDialog(
@@ -121,7 +168,7 @@ class NormalOlfactoryTrainingAnswerScreen extends StatelessWidget {
 
       await NormalOlfactoryTrainingApi.submitTrainingLog(
         totalTimeTaken,
-        normalOlfactoryTrainingController.logs.map((e) => e.toJson()).toList()
+        normalOlfactoryTrainingController.logs.map((e) => e.toJson()).toList(),
       );
 
       Get.off(() => NormalOlfactoryTrainingResultScreen());
@@ -159,88 +206,127 @@ class NormalOlfactoryTrainingAnswerScreen extends StatelessWidget {
         ],
       ),
       body: SafeArea(
-        child: Stack(
-          children: [
-            Positioned(
-              top: 80,
-              child: Image.asset(
-                'assets/images/blurred_background.png',
-                fit: BoxFit.cover,
-                opacity: AlwaysStoppedAnimation(0.5),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  const SizedBox(height: 24),
-                  Row(
-                    children: [
-                      IconButton(
-                        onPressed: () {
-                          showTrainingStopModal(context);
-                        },
-                        icon: const Icon(Icons.arrow_back_ios_new, size: 20),
-                      ),
-                      const Text(
-                        '일반 후각 훈련',
-                        style: TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
+        child:
+            isLoading
+                ? Container(
+                  color: Colors.black.withOpacity(0.5), // 화면 어두워짐
+                  child: Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        CircularProgressIndicator(color: Colors.white),
+                        SizedBox(height: 16),
+                        Text(
+                          '로딩 중...',
+                          style: TextStyle(color: Colors.white, fontSize: 16),
                         ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 16),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 5),
-                    child: Text(
-                      '${normalOlfactoryTrainingController.isCorrect ? "맞았어요!" : "앗, 아쉬워요!"} 방금 맡은 향은\n${normalOlfactoryTrainingController.correctOption} 향이었습니다.',
-                      style: TextStyle(
-                        fontSize: 28,
-                        fontWeight: FontWeight.bold,
-                      ),
-                      textAlign: TextAlign.center,
+                      ],
                     ),
                   ),
-                  const SizedBox(height: 128),
-                  normalOlfactoryTrainingController.currentRound.value != 4
-                      ? Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 5),
-                        child: Text(
-                          "잠깐의 휴식 후, 훈련을 계속 진행해주세요!",
-                          style: TextStyle(
-                            fontSize: 18,
-                            fontWeight: FontWeight.bold,
+                )
+                : Stack(
+                  children: [
+                    Positioned(
+                      top: 80,
+                      child: Image.asset(
+                        'assets/images/blurred_background.png',
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 20),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          const SizedBox(height: 24),
+                          Row(
+                            children: [
+                              IconButton(
+                                onPressed: () {
+                                  showTrainingStopModal(context);
+                                },
+                                icon: const Icon(
+                                  Icons.arrow_back_ios_new,
+                                  size: 20,
+                                ),
+                              ),
+                              const Text(
+                                '일반 후각 훈련',
+                                style: TextStyle(
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ],
                           ),
-                          textAlign: TextAlign.center,
-                        ),
-                      )
-                      : SizedBox.shrink(),
-                  const SizedBox(height: 12),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 24,
-                      vertical: 16,
-                    ),
-                    child: ButtonBasic(
-                      content:
+                          const SizedBox(height: 16),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 5),
+                            child: Text(
+                              '${normalOlfactoryTrainingController.isCorrect ? "맞았어요!" : "앗, 아쉬워요!"} 방금 맡은 향은\n${normalOlfactoryTrainingController.correctOption} 향이었습니다.',
+                              style: TextStyle(
+                                fontSize: 28,
+                                fontWeight: FontWeight.bold,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                          // const SizedBox(height: 128),
                           normalOlfactoryTrainingController
                                       .currentRound
                                       .value !=
                                   4
-                              ? "다음 향 맡아보기"
-                              : "훈련 결과 보기",
-                      icon: Icon(Icons.double_arrow),
-                      function: nextRound,
+                              ? Expanded(
+                                child: Center(
+                                  child: Column(
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      Text(
+                                        remainTime.toString(),
+                                        style: const TextStyle(
+                                          fontSize: 92,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                      const SizedBox(height: 8),
+                                      Text(
+                                        message,
+                                        style: TextStyle(
+                                          fontSize: 24,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              )
+                              : Expanded(
+                                child: Center(
+                                  child: Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 24,
+                                      vertical: 16,
+                                    ),
+                                    child: ButtonBasic(
+                                      content:
+                                          normalOlfactoryTrainingController
+                                                      .currentRound
+                                                      .value !=
+                                                  4
+                                              ? "다음 향 맡아보기"
+                                              : "훈련 결과 보기",
+                                      icon: Icon(Icons.double_arrow),
+                                      function: nextRound,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                          const SizedBox(height: 60),
+                        ],
+                      ),
                     ),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
+                  ],
+                ),
       ),
     );
   }

--- a/lib/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_screen.dart
+++ b/lib/features/normal_olfactory_training/presentation/screens/normal_olfactory_training_screen.dart
@@ -17,7 +17,7 @@ class _NormalOlfactoryTrainingScreenState
     extends State<NormalOlfactoryTrainingScreen> {
   final normalOlfactoryTrainingController =
       Get.find<NormalOlfactoryTrainingController>();
-  int remainTime = 2;
+  int remainTime = 20;
   String message = "초 뒤, 발향이 중지됩니다.";
   bool isStopped = false;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 //import 'package:deepscent_cnu/presentation/screens/%08signup.dart';
 import 'package:flutter/material.dart';
 import 'features/login/presentation/screens/login.dart';
-import 'features/normal_olfactory_training/presentation/screens/memory_recall_training_screen.dart';
 
 void main() {
   runApp(const MyApp());


### PR DESCRIPTION
# 인증 관련 변경 사항
- 액세스 토큰을 런타임에서 관리하는 컨트롤러를 추가함 (AuthController)
- 해당 컨트롤러로 액세스 토큰을 저장 및 사용 가능
- 기존 인증 로직들을 그대로 유지하여 테스트 사용자를 위해 필요한 최소한의 보안성을 확보하면서, 개발할 때 테스트 편의성도 챙기고 사용자 편의성도 챙기는 방식을 고안하였음. 활용법은 아래와 같음

<br/>

## 예시 코드 (NormalOlfactoryTrainingApi 일부 코드)

```dart
final authController = Get.find<AuthController>(); // <<<<<<<<<<<<<<<
    final apiUrl =
        '$apiBaseUrl/api/device/$deviceId/fragrance/scent-option?round=$round';
    final requestHeaders = {
      'Content-type': 'application/json',
      'Authorization': 'Bearer ${authController.accessToken.value}', // <<<<<<<<<<<<<<<
    };
```
사용자 인증이 필요한 API(=액세스 토큰 필요)를 사용하려는 경우, 위와 같이 AuthController를 통해 액세스 토큰을 꺼내서 쓰면 됨.

<br/>

## 예시 코드 (main_preview.dart 일부 코드)

```dart 
void main() async {
  WidgetsFlutterBinding.ensureInitialized(); // <<<<<<<<<<<<<<<
  final authController = Get.put(AuthController()); // <<<<<<<<<<<<<<<
  await authController.adminLogin(); // <<<<<<<<<<<<<<<

  Get.put(NormalOlfactoryTrainingController());
  runApp(const MyApp());
  debugPrint(authController.accessToken.value);
}
```
위와 같이 main_preview.dart 내의 main 함수 안에, AuthController 등록과 관리자 계정 로그인 과정이 자동으로 선행되어 실행되므로, 개발하다가 테스트를 할 때 따로 로그인 같은걸 해줄 필요가 없고, 이미 AuthController에 액세스 토큰이 들어있으므로 그걸 꺼내 쓰기만 하면 됨

<br/>
<hr/>
<br/>

```dart
class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return GetMaterialApp(
      home: OlfactoryTrainingListScreen(), // <<<<<<<<<<<<<<<
      debugShowCheckedModeBanner: false,
    );
  }
}
```

앱의 시작 화면 지점을 정할 때는 main_preview.dart 내의 build 부분에 home에 들어가는 위젯을 대상 스크린으로 수정해주면 됨