### PR TITLE
feat: 기억 회상 훈련 UI 및 동작 개선

### DIFF
--- a/lib/features/memory_recall_training/presentation/screens/memory_recall_chat_screen.dart
+++ b/lib/features/memory_recall_training/presentation/screens/memory_recall_chat_screen.dart
@@ -16,6 +16,7 @@ class MemoryRecallChatScreen extends StatefulWidget {
 }
 
 class _MemoryRecallChatScreenState extends State<MemoryRecallChatScreen> {
+  final _scrollCtrl = ScrollController();
   int currentIndex = 0;
   int interactionCount = 0;
   final AudioRecorder _recorder = AudioRecorder();
@@ -42,6 +43,7 @@ class _MemoryRecallChatScreenState extends State<MemoryRecallChatScreen> {
 
   @override
   void dispose() {
+    _scrollCtrl.dispose();
     stopwatch.stop();
     timer?.cancel();
     super.dispose();
@@ -211,8 +213,11 @@ class _MemoryRecallChatScreenState extends State<MemoryRecallChatScreen> {
                         ],
                       ),
                       child: Scrollbar(
+                        controller: _scrollCtrl,
                         thumbVisibility: true,
                         child: SingleChildScrollView(
+                          controller: _scrollCtrl,
+                          primary: false,
                           padding: const EdgeInsets.only(right: 10),
                           child: Text(
                             transcriptText ?? testAnswerList[0],

--- a/lib/features/memory_recall_training/presentation/screens/memory_recall_chat_screen.dart
+++ b/lib/features/memory_recall_training/presentation/screens/memory_recall_chat_screen.dart
@@ -51,6 +51,15 @@ class _MemoryRecallChatScreenState extends State<MemoryRecallChatScreen> {
 
   void toggleRecording() async {
     if (!isRecording) {
+      // 권한 확인/요청
+      final hasPerm = await _recorder.hasPermission();
+      if (!hasPerm) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('마이크 권한이 필요합니다. 설정에서 허용해 주세요.')),
+        );
+        return;
+      }
+      
       final dir = await getApplicationDocumentsDirectory();
       _filePath = '${dir.path}/recorded_audio.wav';
 
@@ -172,7 +181,7 @@ class _MemoryRecallChatScreenState extends State<MemoryRecallChatScreen> {
           SafeArea(
             child: SingleChildScrollView(
               padding: const EdgeInsets.symmetric(horizontal: 20)
-                  .copyWith(bottom: 200),
+                  .copyWith(bottom: 500),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [

--- a/lib/features/memory_recall_training/presentation/screens/memory_recall_chat_screen.dart
+++ b/lib/features/memory_recall_training/presentation/screens/memory_recall_chat_screen.dart
@@ -166,12 +166,13 @@ class _MemoryRecallChatScreenState extends State<MemoryRecallChatScreen> {
             child: Image.asset(
               'assets/images/blurred_background_2.png',
               fit: BoxFit.cover,
-              alignment: Alignment.center,
+              alignment: Alignment.topCenter
             ),
           ),
           SafeArea(
             child: SingleChildScrollView(
-              padding: const EdgeInsets.symmetric(horizontal: 20),
+              padding: const EdgeInsets.symmetric(horizontal: 20)
+                  .copyWith(bottom: 200),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [

--- a/lib/features/memory_recall_training/presentation/screens/memory_recall_chat_screen.dart
+++ b/lib/features/memory_recall_training/presentation/screens/memory_recall_chat_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:deepscent_cnu/common/widgets/button_basic.dart';
 import 'package:deepscent_cnu/features/memory_recall_training/presentation/screens/memory_recall_result_screen.dart';
+import 'package:deepscent_cnu/features/training_list/presentation/screens/olfactory_training_list.dart';
 import 'package:deepscent_cnu/features/normal_olfactory_training/data/memory_recall_training_api.dart';
 import 'package:flutter/material.dart';
 import 'package:record/record.dart';
@@ -142,6 +143,100 @@ class _MemoryRecallChatScreenState extends State<MemoryRecallChatScreen> {
     return "$minutes:$remainingSeconds";
   }
 
+  void showTrainingCarouselModal(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return Dialog(
+          // 둥근 모양의 다이얼로그 박스
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: StatefulBuilder(
+            builder: (context, setState) {
+              return SizedBox(
+                width: 300, // 모달 너비
+                height: 450, // 모달 높이
+                child: Column(
+                  children: [
+                    Expanded(
+                      // 남은 영역을 PageView로 채움 (좌우로 넘길 수 있는 영역)
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0), // 내용 여백
+                        child: Column(
+                          mainAxisAlignment:
+                              MainAxisAlignment.center, // 세로 중앙 정렬
+                          children: [
+                            Text(
+                              // 안내 멘트 텍스트
+                              '훈련 중지를 원하시나요?',
+                              style: const TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                            const SizedBox(height: 20), // 위아래 여백
+                            Text(
+                              // 안내 멘트 텍스트
+                              '지금까지 진행한 훈련 기록이 모두 삭제됩니다.',
+                              style: const TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                            const SizedBox(height: 20),
+                            const Divider(
+                              // 구분선
+                              thickness: 1,
+                              height: 1,
+                              color: Color(0xFFE0E0E0),
+                            ),
+                            const SizedBox(height: 24),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 32,
+                                vertical: 16,
+                              ),
+                              child: ButtonBasic(
+                                content: '훈련 재개하기',
+                                icon: Icon(Icons.rocket_launch, size: 20),
+                                function: () => {Navigator.pop(context)},
+                              ),
+                            ),
+                            const SizedBox(height: 12),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 32,
+                                vertical: 16,
+                              ),
+                              child: ButtonBasic(
+                                content: '훈련 끝내기',
+                                icon: Icon(Icons.exit_to_app, size: 20),
+                                function: () {
+                                  Navigator.of(context).pushAndRemoveUntil(
+                                    MaterialPageRoute(builder: (_) => const OlfactoryTrainingListScreen()),
+                                    (route) => false,
+                                  );
+                                },
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -189,7 +284,7 @@ class _MemoryRecallChatScreenState extends State<MemoryRecallChatScreen> {
                   Row(
                     children: [
                       IconButton(
-                        onPressed: () => Navigator.pop(context),
+                        onPressed: () => showTrainingCarouselModal(context),
                         icon: const Icon(Icons.arrow_back_ios_new, size: 20),
                       ),
                       const Text(

--- a/lib/features/memory_recall_training/presentation/screens/memory_recall_result_screen.dart
+++ b/lib/features/memory_recall_training/presentation/screens/memory_recall_result_screen.dart
@@ -1,4 +1,5 @@
 import 'package:deepscent_cnu/common/widgets/button_basic.dart';
+import 'package:deepscent_cnu/features/training_list/presentation/screens/olfactory_training_list.dart';
 import 'package:flutter/material.dart';
 
 class MemoryRecallResultScreen extends StatelessWidget {
@@ -34,8 +35,8 @@ class MemoryRecallResultScreen extends StatelessWidget {
       body: SafeArea(
         child: Stack(
           children: [
-            Positioned(
-              top: 80,
+            Positioned.fill(
+              top: 50,
               child: Image.asset(
                 'assets/images/blurred_background_2.png',
                 fit: BoxFit.cover,
@@ -50,7 +51,10 @@ class MemoryRecallResultScreen extends StatelessWidget {
                     children: [
                       IconButton(
                         onPressed: () {
-                          Navigator.pop(context);
+                          Navigator.of(context).pushAndRemoveUntil(
+                            MaterialPageRoute(builder: (_) => const OlfactoryTrainingListScreen()),
+                            (route) => false,
+                          );
                         },
                         icon: const Icon(Icons.arrow_back_ios_new, size: 20),
                       ),
@@ -133,7 +137,13 @@ class MemoryRecallResultScreen extends StatelessWidget {
                     child: ButtonBasic(
                       content: '훈련 목록 보기',
                       icon: Icon(Icons.list, size: 30),
-                      function: () {},
+                      function: () {
+                        // 스택을 비우고 목록으로 이동 (뒤로가기 눌러도 결과 화면 안 돌아오게)
+                        Navigator.of(context).pushAndRemoveUntil(
+                          MaterialPageRoute(builder: (_) => const OlfactoryTrainingListScreen()),
+                          (route) => false,
+                        );
+                      },
                     ),
                   ),
                 ],

--- a/lib/features/memory_recall_training/presentation/screens/memory_recall_scent_select_screen.dart
+++ b/lib/features/memory_recall_training/presentation/screens/memory_recall_scent_select_screen.dart
@@ -42,6 +42,7 @@ class MemoryRecallScentSelectScreen extends StatelessWidget {
         children: [
           // 흐릿한 배경 이미지
           Positioned.fill(
+            top: 50,
             child: Image.asset(
               'assets/images/blurred_background.png',
               fit: BoxFit.cover,

--- a/lib/features/memory_recall_training/presentation/screens/memory_recall_session_select_screen.dart
+++ b/lib/features/memory_recall_training/presentation/screens/memory_recall_session_select_screen.dart
@@ -40,6 +40,7 @@ class MemoryRecallSessionSelectScreen extends StatelessWidget {
         children: [
           // 흐릿한 배경 이미지
           Positioned.fill(
+            top: 50,
             child: Image.asset(
               'assets/images/blurred_background.png',
               fit: BoxFit.cover,

--- a/lib/features/memory_recall_training/presentation/screens/memory_recall_training_screen.dart
+++ b/lib/features/memory_recall_training/presentation/screens/memory_recall_training_screen.dart
@@ -13,7 +13,7 @@ class MemoryRecallTrainingScreen extends StatefulWidget {
 
 class MemoryRecallTrainingScreenState
     extends State<MemoryRecallTrainingScreen> {
-  int remainTime = 2;
+  int remainTime = 10;
   String message = "초 뒤, 발향이 중지됩니다.";
   bool isStopped = false;
   bool showHelp = false;
@@ -61,6 +61,7 @@ class MemoryRecallTrainingScreenState
     await DeviceApi.controlScentDeviceSlot(1, 0);
 
     if (context.mounted) {
+      Navigator.pop(context);
       Navigator.pop(context);
       Navigator.pop(context);
     }

--- a/lib/features/memory_recall_training/presentation/screens/memory_recall_training_screen.dart
+++ b/lib/features/memory_recall_training/presentation/screens/memory_recall_training_screen.dart
@@ -13,7 +13,7 @@ class MemoryRecallTrainingScreen extends StatefulWidget {
 
 class MemoryRecallTrainingScreenState
     extends State<MemoryRecallTrainingScreen> {
-  int remainTime = 10;
+  int remainTime = 2;
   String message = "초 뒤, 발향이 중지됩니다.";
   bool isStopped = false;
   bool showHelp = false;
@@ -195,7 +195,7 @@ class MemoryRecallTrainingScreenState
       body: SafeArea(
         child: Stack(
           children: [
-            Positioned(
+            Positioned.fill(
               top: 80,
               child: Image.asset(
                 'assets/images/blurred_background.png',


### PR DESCRIPTION
### 변경 사항
- 회차 선택 → 향기 선택 화면 이동 로직 구현
- STT 녹음 전 마이크 권한 확인 및 요청 추가
- Scrollbar와 내부 스크롤 뷰에 동일한 ScrollController 적용 (타이머가 끝나도 이동 안 됐던 원인)
- 배경 이미지 위치 및 정렬 수정으로 자연스럽게 표시
- 각종 버튼 클릭 시 목록 화면으로 이동 기능 추가