### PR TITLE
fix: AndroidManifest 인터넷 권한 추가

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-<uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
+        android:usesCleartextTraffic="true"
         android:label="deepscent_cnu"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">


### PR DESCRIPTION
- 에뮬레이터에서는 서버 통신이 가능했지만, 실제 기기에서 네트워크 연결이 되지 않는 문제
- 릴리즈 빌드에서 인터넷 사용 가능하도록 `AndroidManifest` 권한 수정
- [관련 자료](https://stackoverflow.com/questions/72485529/flutter-build-apk-release-build-the-apk-file-but-it-give-error-after-installin)